### PR TITLE
fix: use correct subcommand name in json generation

### DIFF
--- a/zcli-json.ts
+++ b/zcli-json.ts
@@ -79,7 +79,7 @@ export async function zcliJson<
             })
           ) {
             if (flags.all || !cmd.hidden) {
-              commands.push(generateCommand(cmd, [...path, command.name]));
+              commands.push(generateCommand(cmd, [...path, cmd.name]));
             }
           }
 


### PR DESCRIPTION
The `zcliJson()` function is using the parent command's name to generate the path instead of the command itself.